### PR TITLE
from freenode irc #node.js channel 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"keywords" : ["money", "fx", "currency", "exchange", "utilities", "accounting"],
 	"author": "Joss Crowcroft <josscrowcroft@gmail.com> (http://www.josscrowcroft.com)",
 	"contributors" : [],
-	"dependencies" : [],
+	"dependencies" : {},
 	"repository" : {"type": "git", "url": "git://github.com/josscrowcroft/money.js.git"},
 	"main" : "money.js",
 	"version" : "0.1.1"


### PR DESCRIPTION
Chat log bellow explains the reason for this pull request, (Thanks to **isaacs**!)

> **panosru:** hi, every time I run npm commands I get this: `npm WARN money@0.0.1 dependencies field should > be hash of <name>:<version-range> pairs` do you use money.js ?
> **isaacs:** _panosru:_ looks like the money package has an incorrect dependencies field in their package.json
> **isaacs:** _panosru:_ you should send them a pull request
