### PR TITLE
Throw actual Error instance and improve error message

### DIFF
--- a/money.js
+++ b/money.js
@@ -75,7 +75,19 @@
 		rates[fx.base] = 1;
 
 		// Throw an error if either rate isn't in the rates array
-		if ( !rates[to] || !rates[from] ) throw "fx error";
+		if ( !rates[to] || !rates[from] ) {
+			var msg = 'Cannot convert ' + from + ' to ' + to + ': ';
+
+			if ( !rates[to] && !rates[from] ) {
+				msg += 'exhange rates for both currencies are missing';
+			} else if ( !rates[to] ) {
+				msg += 'exhange rate for ' + to + ' is missing';
+			} else if ( !rates[from] ) {
+				msg += 'exhange rate for ' + from + ' is missing';
+			}
+
+			throw new Error( msg );
+		}
 
 		// If `from` currency === fx.base, return the basic exchange rate for the `to` currency
 		if ( from === fx.base ) {

--- a/money.js
+++ b/money.js
@@ -79,11 +79,11 @@
 			var msg = 'Cannot convert ' + from + ' to ' + to + ': ';
 
 			if ( !rates[to] && !rates[from] ) {
-				msg += 'exhange rates for both currencies are missing';
+				msg += 'exchange rates for both currencies are missing';
 			} else if ( !rates[to] ) {
-				msg += 'exhange rate for ' + to + ' is missing';
+				msg += 'exchange rate for ' + to + ' is missing';
 			} else if ( !rates[from] ) {
-				msg += 'exhange rate for ' + from + ' is missing';
+				msg += 'exchange rate for ' + from + ' is missing';
 			}
 
 			throw new Error( msg );


### PR DESCRIPTION
Related to #8 and #13

Only `Error` instances in JavaScript provide a stack - this is why there is no stack available, because a simple string is thrown. This PR addresses this issue by throwing an actual `Error` instance and providing a more detail error message, such as: `Cannot convert EUR to USD: exchange rate for USD is missing`.
