### PR TITLE
fixed typo with ... in opts fx.converted section

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@ var fxSetup = {
 	}
 };</pre>
 
-			<h4 id="fx.convert">fx.convert(val, <em>[opts]</em>)</h4>
+			<h4 id="fx.convert">fx.convert(val, <em>[opts...]</em>)</h4>
 
 			<p>The basic function of the library - converts a value from one currency to another. Uses the default <code>from</code> and <code>to</code> currencies in <code>fx.settings</code>, or those given in <code>opts</code>:</p>
 			<pre class="prettyprint">// Using defaults:


### PR DESCRIPTION
Since we can have multiple options like from, to we have displayed rest operator to look visually appealing.